### PR TITLE
chore(deps): force dompurify >=3.4.12 via overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11741,15 +11741,6 @@
                 "marked": "14.0.0"
             }
         },
-        "node_modules/monaco-editor/node_modules/dompurify": {
-            "version": "3.2.7",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
-            "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
-            "license": "(MPL-2.0 OR Apache-2.0)",
-            "optionalDependencies": {
-                "@types/trusted-types": "^2.0.7"
-            }
-        },
         "node_modules/monaco-editor/node_modules/marked": {
             "version": "14.0.0",
             "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -14,5 +14,8 @@
     },
     "devDependencies": {
         "playwright-chromium": "^1.49.1"
+    },
+    "overrides": {
+        "dompurify": "^3.4.12"
     }
 }


### PR DESCRIPTION
Добавляет `overrides` в package.json, форсирующий `dompurify@^3.4.12` для всего дерева зависимостей.

## Зачем
`monaco-editor@0.55.1` тянул уязвимый `dompurify@3.2.7`. Override поднимает все вхождения до `3.4.12`.

## Результат
- Закрывает **11 из 12** открытых Dependabot-алертов по `dompurify`.
- `npm audit` — 0 vulnerabilities.
- Алерт #85 (low, `IN_PLACE nodeName`) не имеет патча ни в одной опубликованной версии — закрыть нечем.

Практический риск минимальный: статичная сборка слайдов Slidev, недоверенный HTML не санитизируется.